### PR TITLE
chore: (main) release  @contensis/canvas-react v1.0.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.1",
+  "packages/react": "1.0.2",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.0.2](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.1...@contensis/canvas-react-v1.0.2) (2023-12-14)
+
+
+### Documentation
+
+* JSDoc comments for the exported React functions ([#10](https://github.com/contensis/canvas/issues/10)) ([2f053ba](https://github.com/contensis/canvas/commit/2f053ba398603a767deb9c5b1a6c4a07788e3b0b))
+
+
+### Bug Fixes
+
+* missing types in `canvas-react` ([133509b](https://github.com/contensis/canvas/commit/133509b73747416d191903b3400f3848869ccbfc))
+* null is valid JSX return type ([4c9b20b](https://github.com/contensis/canvas/commit/4c9b20b959e3e88eeb373e2242f8db1824085a10))
+
 ## [1.0.1](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.0...@contensis/canvas-react-v1.0.1) (2023-12-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.2](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.1...@contensis/canvas-react-v1.0.2) (2023-12-14)


### Documentation

* JSDoc comments for the exported React functions ([#10](https://github.com/contensis/canvas/issues/10)) ([2f053ba](https://github.com/contensis/canvas/commit/2f053ba398603a767deb9c5b1a6c4a07788e3b0b))


### Bug Fixes

* missing types in `canvas-react` ([133509b](https://github.com/contensis/canvas/commit/133509b73747416d191903b3400f3848869ccbfc))
* null is valid JSX return type ([4c9b20b](https://github.com/contensis/canvas/commit/4c9b20b959e3e88eeb373e2242f8db1824085a10))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).