### PR TITLE
chore: (main) release  @contensis/canvas-react v1.0.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.2",
+  "packages/react": "1.0.3",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.3](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.2...@contensis/canvas-react-v1.0.3) (2024-01-16)
+
+
+### Build
+
+* avoid `Can't resolve 'react/jsx-runtime'` error in consumer projects ([aac6cc3](https://github.com/contensis/canvas/commit/aac6cc3b7ada157a6fd9236c44d840f0d8ee71cd))
+
 ## [1.0.2](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.1...@contensis/canvas-react-v1.0.2) (2023-12-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.3](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.2...@contensis/canvas-react-v1.0.3) (2024-01-16)


### Build

* avoid `Can't resolve 'react/jsx-runtime'` error in consumer projects ([aac6cc3](https://github.com/contensis/canvas/commit/aac6cc3b7ada157a6fd9236c44d840f0d8ee71cd))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).