### PR TITLE
chore: (main) release  @contensis/canvas-react v1.0.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.3",
+  "packages/react": "1.0.4",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.4](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.3...@contensis/canvas-react-v1.0.4) (2024-01-18)
+
+
+### Bug Fixes
+
+* avoid duplicate versions of react when using yarn package manager ([cff2046](https://github.com/contensis/canvas/commit/cff2046a59d0e6ee35065196396acea167863187))
+
+
+### Build
+
+* update project dev dependencies ([08ff7bd](https://github.com/contensis/canvas/commit/08ff7bd4f3479e61e452c7be587462ae17834bfb))
+
 ## [1.0.3](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.2...@contensis/canvas-react-v1.0.3) (2024-01-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.4](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.3...@contensis/canvas-react-v1.0.4) (2024-01-18)


### Bug Fixes

* avoid duplicate versions of react when using yarn package manager ([cff2046](https://github.com/contensis/canvas/commit/cff2046a59d0e6ee35065196396acea167863187))


### Build

* update project dev dependencies ([08ff7bd](https://github.com/contensis/canvas/commit/08ff7bd4f3479e61e452c7be587462ae17834bfb))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).