### PR TITLE
chore: (main) release  @contensis/canvas-react v1.0.5

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.4",
+  "packages/react": "1.0.5",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.5](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.4...@contensis/canvas-react-v1.0.5) (2024-05-02)
+
+
+### Bug Fixes
+
+* issue building some webpack projects without adding this node_module to the babel include list ([ad2b797](https://github.com/contensis/canvas/commit/ad2b797ee4dca905e2e9b1006042ec2fe9f7e553))
+
+
+### Build
+
+* avoid .mjs extension in esm builds to prevent error `Can't import the named export 'useContext' from non EcmaScript module` in legacy consumer webpack builds ([4470cb8](https://github.com/contensis/canvas/commit/4470cb829975cd6f79a7ca6f4018c5f9de09cf09))
+
 ## [1.0.4](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.3...@contensis/canvas-react-v1.0.4) (2024-01-18)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.5](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.4...@contensis/canvas-react-v1.0.5) (2024-05-02)


### Bug Fixes

* issue building some webpack projects without adding this node_module to the babel include list ([ad2b797](https://github.com/contensis/canvas/commit/ad2b797ee4dca905e2e9b1006042ec2fe9f7e553))


### Build

* avoid .mjs extension in esm builds to prevent error `Can't import the named export 'useContext' from non EcmaScript module` in legacy consumer webpack builds ([4470cb8](https://github.com/contensis/canvas/commit/4470cb829975cd6f79a7ca6f4018c5f9de09cf09))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).