### PR TITLE
chore: (main) release  @contensis/canvas-react v1.0.6

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.5",
+  "packages/react": "1.0.6",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.6](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.5...@contensis/canvas-react-v1.0.6) (2024-05-22)
+
+
+### Bug Fixes
+
+* missing export `RenderChildren` for rendering a value that may be a composite block array inside an overridden block render component ([f3dae2f](https://github.com/contensis/canvas/commit/f3dae2fbf3323795226007a79b0739bbc296a4d1))
+
 ## [1.0.5](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.4...@contensis/canvas-react-v1.0.5) (2024-05-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.6](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.5...@contensis/canvas-react-v1.0.6) (2024-05-22)


### Bug Fixes

* missing export `RenderChildren` for rendering a value that may be a composite block array inside an overridden block render component ([f3dae2f](https://github.com/contensis/canvas/commit/f3dae2fbf3323795226007a79b0739bbc296a4d1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).