### PR TITLE
chore: (main) release  @contensis/canvas-react v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/react": "1.0.6",
+  "packages/react": "1.1.0",
   "packages/html": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.6...@contensis/canvas-react-v1.1.0) (2024-07-05)
+
+
+### Features
+
+* handle forms as a canvas block type ([#17](https://github.com/contensis/canvas/issues/17)) ([5f6e93c](https://github.com/contensis/canvas/commit/5f6e93c698359e23a02f10ee9d41ccb1b30e344c))
+
 ## [1.0.6](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.5...@contensis/canvas-react-v1.0.6) (2024-05-22)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.6...@contensis/canvas-react-v1.1.0) (2024-07-05)


### Features

* handle forms as a canvas block type ([#17](https://github.com/contensis/canvas/issues/17)) ([5f6e93c](https://github.com/contensis/canvas/commit/5f6e93c698359e23a02f10ee9d41ccb1b30e344c))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).