### PR TITLE
chore: (main) release  @contensis/canvas-html v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/react": "1.0.6",
-  "packages/html": "1.0.0"
+  "packages/html": "1.1.0"
 }

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.0.0...@contensis/canvas-html-v1.1.0) (2024-07-05)
+
+
+### Features
+
+* handle forms as a canvas block type ([#17](https://github.com/contensis/canvas/issues/17)) ([5f6e93c](https://github.com/contensis/canvas/commit/5f6e93c698359e23a02f10ee9d41ccb1b30e344c))
+
 ## 1.0.0 (2023-12-01)
 
 

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-html",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Render canvas content to HTML",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.0.0...@contensis/canvas-html-v1.1.0) (2024-07-05)


### Features

* handle forms as a canvas block type ([#17](https://github.com/contensis/canvas/issues/17)) ([5f6e93c](https://github.com/contensis/canvas/commit/5f6e93c698359e23a02f10ee9d41ccb1b30e344c))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).