### PR TITLE
chore: (main) release  @contensis/canvas-react v1.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.1.0",
+  "packages/react": "1.2.0",
   "packages/html": "1.1.0",
   "packages/html-canvas": "1.0.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Features
 
 * add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+* added default forms render ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+* updated rendering of forms within canvas and ensured canvas renderer can handle unknown types ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
 
 
 ### Build

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.1.0...@contensis/canvas-react-v1.2.0) (2024-09-26)
+
+
+### Features
+
+* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+
+
+### Build
+
+* use .mjs extension for ESM build - reverts change in v1.0.5 and fixes [#20](https://github.com/contensis/canvas/issues/20) `Cannot use import statement outside a module` when project specifies `type: module` ([aacbae8](https://github.com/contensis/canvas/commit/aacbae87695e8b965445b9957fc99b65563b61df))
+
 ## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.0.6...@contensis/canvas-react-v1.1.0) (2024-07-05)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.1.0...@contensis/canvas-react-v1.2.0) (2024-09-26)


### Features

* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
* added default forms render ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
* updated rendering of forms within canvas and ensured canvas renderer can handle unknown types ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))

### Build

* use .mjs extension for ESM build - reverts change in v1.0.5 and fixes [#20](https://github.com/contensis/canvas/issues/20) `Cannot use import statement outside a module` when project specifies `type: module` ([aacbae8](https://github.com/contensis/canvas/commit/aacbae87695e8b965445b9957fc99b65563b61df))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).