### PR TITLE
chore: (main) release  @contensis/html-canvas v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.2.0",
   "packages/html": "1.1.0",
-  "packages/html-canvas": "1.0.0"
+  "packages/html-canvas": "1.1.0"
 }

--- a/packages/html-canvas/CHANGELOG.md
+++ b/packages/html-canvas/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 * add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+* parse forms in html ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
 
 ## 1.0.0 (2024-08-09)
 

--- a/packages/html-canvas/CHANGELOG.md
+++ b/packages/html-canvas/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/html-canvas-v1.0.0...@contensis/html-canvas-v1.1.0) (2024-09-26)
+
+
+### Features
+
+* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+
 ## 1.0.0 (2024-08-09)
 
 

--- a/packages/html-canvas/package.json
+++ b/packages/html-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/html-canvas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Convert HTML to Contensis Canvas",
   "scripts": {
     "build": "tsup-node --dts-resolve",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/html-canvas-v1.0.0...@contensis/html-canvas-v1.1.0) (2024-09-26)


### Features

* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
* parse forms in html ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).