### PR TITLE
chore: (main) release  @contensis/canvas-html v1.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "1.2.0",
-  "packages/html": "1.1.0",
+  "packages/html": "1.2.0",
   "packages/html-canvas": "1.0.0"
 }

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.1.0...@contensis/canvas-html-v1.2.0) (2024-09-26)
 
 
-### Build
+### Features
 
-* install dev dependencies as npm local package for release-please `always-link-local` manifest option to pick up changes ([57bf0fc](https://github.com/contensis/canvas/commit/57bf0fc1ca74a3a4758d3e86c2bcb14285c3fdb9))
+* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+* added default forms render ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
+* updated rendering of forms within canvas and ensured canvas renderer can handle unknown types ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
 
 ## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.0.0...@contensis/canvas-html-v1.1.0) (2024-07-05)
 

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.1.0...@contensis/canvas-html-v1.2.0) (2024-09-26)
+
+
+### Build
+
+* install dev dependencies as npm local package for release-please `always-link-local` manifest option to pick up changes ([57bf0fc](https://github.com/contensis/canvas/commit/57bf0fc1ca74a3a4758d3e86c2bcb14285c3fdb9))
+
 ## [1.1.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.0.0...@contensis/canvas-html-v1.1.0) (2024-07-05)
 
 

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-html",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Render canvas content to HTML",
   "keywords": [
     "contensis",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,8 +13,7 @@
   ],
   "packages": {
     "packages/html": {
-      "component": "@contensis/canvas-html",
-      "release-as": "1.2.0"
+      "component": "@contensis/canvas-html"
     },
     "packages/react": {
       "component": "@contensis/canvas-react"


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.1.0...@contensis/canvas-html-v1.2.0) (2024-09-26)


### Features

* add support for Liquid canvas blocks ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
* added default forms render ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))
* updated rendering of forms within canvas and ensured canvas renderer can handle unknown types ([#22](https://github.com/contensis/canvas/issues/22)) ([c18c591](https://github.com/contensis/canvas/commit/c18c5918a64c4e6ad9cf00daf0f65c00af507159))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).