### PR TITLE
chore: (main) release  @contensis/canvas-react v1.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.2.0",
+  "packages/react": "1.3.0",
   "packages/html": "1.2.0",
   "packages/html-canvas": "1.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.2.0...@contensis/canvas-react-v1.3.0) (2025-09-09)
+
+
+### Features
+
+* add entry and asset blocks ([4e05e84](https://github.com/contensis/canvas/commit/4e05e84de3b5ec97246efaf71f4f8aa2ddd4d273))
+* added abbreviation rendering ([#30](https://github.com/contensis/canvas/issues/30)) ([d060c73](https://github.com/contensis/canvas/commit/d060c73d4d365feb4c73fab7ddfc1dbc19e581c4))
+
 ## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.1.0...@contensis/canvas-react-v1.2.0) (2024-09-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.3.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.2.0...@contensis/canvas-react-v1.3.0) (2025-09-09)


### Features

* add entry and asset blocks ([4e05e84](https://github.com/contensis/canvas/commit/4e05e84de3b5ec97246efaf71f4f8aa2ddd4d273))
* added abbreviation rendering ([#30](https://github.com/contensis/canvas/issues/30)) ([d060c73](https://github.com/contensis/canvas/commit/d060c73d4d365feb4c73fab7ddfc1dbc19e581c4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).