### PR TITLE
chore: (main) release  @contensis/canvas-html v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6234,7 +6234,7 @@
     },
     "packages/html": {
       "name": "@contensis/canvas-html",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {
         "@contensis/canvas-dom": "file:../dom",
@@ -6243,7 +6243,7 @@
     },
     "packages/html-canvas": {
       "name": "@contensis/html-canvas",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "htmlparser2": "^9.1.0",
@@ -6369,7 +6369,7 @@
     },
     "packages/react": {
       "name": "@contensis/canvas-react",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {
         "@contensis/canvas-types": "^0.0.1",

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.2.0...@contensis/canvas-html-v1.3.0) (2025-09-09)
+
+
+### Features
+
+* add entry and asset blocks ([4e05e84](https://github.com/contensis/canvas/commit/4e05e84de3b5ec97246efaf71f4f8aa2ddd4d273))
+* added abbreviation rendering ([#30](https://github.com/contensis/canvas/issues/30)) ([d060c73](https://github.com/contensis/canvas/commit/d060c73d4d365feb4c73fab7ddfc1dbc19e581c4))
+
 ## [1.2.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.1.0...@contensis/canvas-html-v1.2.0) (2024-09-26)
 
 

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-html",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Render canvas content to HTML",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.3.0](https://github.com/contensis/canvas/compare/@contensis/canvas-html-v1.2.0...@contensis/canvas-html-v1.3.0) (2025-09-09)


### Features

* add entry and asset blocks ([4e05e84](https://github.com/contensis/canvas/commit/4e05e84de3b5ec97246efaf71f4f8aa2ddd4d273))
* added abbreviation rendering ([#30](https://github.com/contensis/canvas/issues/30)) ([d060c73](https://github.com/contensis/canvas/commit/d060c73d4d365feb4c73fab7ddfc1dbc19e581c4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).