### PR TITLE
Handle empty Canvas data in Renderer

### DIFF
--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -200,24 +200,10 @@ function RenderText(props: RenderTextProps) {
  * 
  * */
 export function Renderer(props: RendererProps) {
-    const allBlocksHaveValue = Array.isArray(props.data) && props.data.every(
-        block => {
-            if (block && typeof block === 'object' && 'value' in block) {
-                if (Array.isArray(block.value)) {
-                    return block.value.length > 0;
-                }
-                if (typeof block.value === 'string') {
-                    return block.value.trim() !== '';
-                }
-                return !!block.value;
-            }
-            return false;
-        }
-    );
+    if (!Array.isArray(props.data) || props.data.length === 0) return null;
 
-    if (!Array.isArray(props.data) || props.data.length === 0 || !allBlocksHaveValue) {
-        return null;
-    }
+    const blocksWithArrayValue = props.data.filter(block => Array.isArray(block.value));
+    if (blocksWithArrayValue.length > 0 && blocksWithArrayValue.every(block => block.value.length === 0)) return null;
 
     return (<RenderBlocks blocks={props.data} />);
 }

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -200,6 +200,25 @@ function RenderText(props: RenderTextProps) {
  * 
  * */
 export function Renderer(props: RendererProps) {
+    const allBlocksHaveValue = Array.isArray(props.data) && props.data.every(
+        block => {
+            if (block && typeof block === 'object' && 'value' in block) {
+                if (Array.isArray(block.value)) {
+                    return block.value.length > 0;
+                }
+                if (typeof block.value === 'string') {
+                    return block.value.trim() !== '';
+                }
+                return !!block.value;
+            }
+            return false;
+        }
+    );
+
+    if (!Array.isArray(props.data) || props.data.length === 0 || !allBlocksHaveValue) {
+        return null;
+    }
+
     return (<RenderBlocks blocks={props.data} />);
 }
 


### PR DESCRIPTION
When working with Canvas fields, the API may return different forms of "empty" data:

- `null`, or
- an array of Block objects where the value field is an empty array `[]`

Previously, consumers of the Canvas React Renderer had to implement their own checks to guard against these cases. Without these checks, rendering could fail or lead to unintended behavior. This inconsistency has also led to multiple internal utilities being created to sanitize the data before rendering.

The intention of this PR is to add a safeguard directly to the Renderer component to gracefully handle these edge cases.