### PR TITLE
chore: (main) release  @contensis/canvas-react v1.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.3.0",
+  "packages/react": "1.3.1",
   "packages/html": "1.3.0",
   "packages/html-canvas": "1.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6369,7 +6369,7 @@
     },
     "packages/react": {
       "name": "@contensis/canvas-react",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "devDependencies": {
         "@contensis/canvas-types": "^0.0.1",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.1](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.3.0...@contensis/canvas-react-v1.3.1) (2026-02-12)
+
+
+### Bug Fixes
+
+* add scope to table headers [#34](https://github.com/contensis/canvas/issues/34) [@dantkid](https://github.com/dantkid) ([5c5393f](https://github.com/contensis/canvas/commit/5c5393f156b1d0bd6c2805f6e8fd9dd3e4e65589))
+
 ## [1.3.0](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.2.0...@contensis/canvas-react-v1.3.0) (2025-09-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.3.1](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.3.0...@contensis/canvas-react-v1.3.1) (2026-02-12)


### Bug Fixes

* add scope to table headers [#34](https://github.com/contensis/canvas/issues/34) [@dantkid](https://github.com/dantkid) ([5c5393f](https://github.com/contensis/canvas/commit/5c5393f156b1d0bd6c2805f6e8fd9dd3e4e65589))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).