### PR TITLE
chore: (main) release  @contensis/canvas-react v1.3.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.3.1",
+  "packages/react": "1.3.2",
   "packages/html": "1.3.0",
   "packages/html-canvas": "1.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7557,7 +7557,7 @@
     },
     "packages/react": {
       "name": "@contensis/canvas-react",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "devDependencies": {
         "@contensis/canvas-types": "^0.0.1",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.2](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.3.1...@contensis/canvas-react-v1.3.2) (2026-02-12)
+
+
+### Bug Fixes
+
+* now using NPM Trusted Publishing ([18a88cc](https://github.com/contensis/canvas/commit/18a88cc3e19c3ebf15a7f5d2ce18b67b55353206))
+
 ## [1.3.1](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.3.0...@contensis/canvas-react-v1.3.1) (2026-02-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/canvas-react",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Render canvas content with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.3.2](https://github.com/contensis/canvas/compare/@contensis/canvas-react-v1.3.1...@contensis/canvas-react-v1.3.2) (2026-02-12)


### Bug Fixes

* now using NPM Trusted Publishing ([18a88cc](https://github.com/contensis/canvas/commit/18a88cc3e19c3ebf15a7f5d2ce18b67b55353206))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).